### PR TITLE
FIX: nil_site crast for first login

### DIFF
--- a/app/controllers/identities_controller.rb
+++ b/app/controllers/identities_controller.rb
@@ -28,7 +28,7 @@ class IdentitiesController < ApplicationController
         sites_api = client.sites
         result = sites_api.list_sites
 
-        if result.success?
+        if result.success? && !result.data.nil?
           result
             .data
             .sites

--- a/app/views/identities/index.html.erb
+++ b/app/views/identities/index.html.erb
@@ -12,6 +12,7 @@
           <div class="col-lg-2">
           </div>
           <div class="col-lg-4">
+          <%= "No sites yet" if identity.sites.empty? %>
           </div>
         </div>
       <% end %>


### PR DESCRIPTION
bug fix for nil sites during 1st time login, if user has no sites.

no sure if i need to leave `result.success?` validaion, and completely replace with `!result.data.nil?`